### PR TITLE
Fix 'last node standing' bug

### DIFF
--- a/examples/launchpad_floodfill.js
+++ b/examples/launchpad_floodfill.js
@@ -21,9 +21,13 @@ function floodfill(launchpad) {
   function animationCycle() {
     setTimeout(animationCycle, 100)
 
-    if (cycles.length === 0) return
-
     let blank = generateBlankSquare(Color.BLACK)
+
+    if (cycles.length === 0) {
+        launchpad.updateBoard(blank)
+        return
+    }
+
     cycles.forEach(cycle => {
       let gen = cycle.shift()
 


### PR DESCRIPTION
When a flood ends in the corner, the last 'pixel' is not cleared. This amazingly coded and designed pull request fixes this problem and shall therefore be called the enterprise solution of leftover corner bugs.

-> :)